### PR TITLE
Add OG URL validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# InfiniteEVSE website
+
+This repository contains the static site for InfiniteEVSE.
+
+## Tests
+
+Run `bash tests/check_meta.sh` to verify that all HTML files contain a
+`<meta property="og:url">` tag starting with `https://infiniteevse.com`.
+The script exits non-zero if any file violates this rule.
+

--- a/tests/check_meta.sh
+++ b/tests/check_meta.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Simple check for og:url meta tags.
+# Usage: bash tests/check_meta.sh
+
+prefix="https://infiniteevse.com"
+errors=0
+
+while IFS= read -r file; do
+  while IFS= read -r tag; do
+    url=$(echo "$tag" | sed -n 's/.*content="\([^"]*\)".*/\1/p')
+    if [[ -n "$url" && $url != $prefix* ]]; then
+      echo "Invalid og:url in $file: $url"
+      errors=1
+    fi
+  done < <(grep -o '<meta[^>]*property="og:url"[^>]*>' "$file")
+done < <(find . -name '*.html')
+
+if [ $errors -ne 0 ]; then
+  echo "Check failed." >&2
+  exit 1
+fi
+
+echo "All og:url meta tags are valid."
+


### PR DESCRIPTION
## Summary
- add simple tests directory with meta tag validation script
- document how to run the test script in README

## Testing
- `bash tests/check_meta.sh` *(fails: invalid og:url in style-guide and credits)*

------
https://chatgpt.com/codex/tasks/task_e_683f75a9051c832bb4efe46cf193e0a4